### PR TITLE
support play subcommand

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod authenticate;
 pub mod concatenate;
+pub mod play;
 pub mod record;
 pub mod upload;

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -1,0 +1,53 @@
+use asciicast::{Entry, Header};
+use commands::record::get_elapsed_seconds;
+use commands::concatenate::get_file;
+use failure::Error;
+use serde_json;
+use settings::PlaySettings;
+use std::io::prelude::*;
+use std::io::{self, BufReader, Write};
+use std::time::Instant;
+use tempfile::NamedTempFile;
+
+#[derive(Debug, Fail)]
+enum PlayFailure {
+    #[fail(display = "header not found")]
+    HeaderNotFound,
+}
+
+pub fn go(settings: &PlaySettings) -> Result<(), Error> {
+    let location = settings.location.clone();
+
+    let mut temp: NamedTempFile = NamedTempFile::new()?;
+
+    let file = get_file(location, &mut temp)?;
+
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+
+    // Skip the first line, and maybe Header is needed later.
+    let _len = reader.read_line(&mut line);
+    let res: Result<Header, serde_json::Error> = serde_json::from_str(line.as_str());
+    let _header = match res {
+        Ok(h) => h,
+        Err(_) => return Err(PlayFailure::HeaderNotFound)?,
+    };
+
+    let base = Instant::now();
+
+    for line in reader.lines() {
+        let entry: Entry = serde_json::from_str(line.unwrap().as_str())?;
+        loop {
+            if entry.time <= get_elapsed_seconds(&base.elapsed()) {
+                handle.write_all(entry.event_data.as_bytes())?;
+                handle.flush()?;
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -37,7 +37,7 @@ enum RecordFailure {
     RawOutputWrite(#[cause] std::io::Error),
 }
 
-fn get_elapsed_seconds(duration: &Duration) -> f64 {
+pub fn get_elapsed_seconds(duration: &Duration) -> f64 {
     duration.as_secs() as f64 + (0.000_000_001 * f64::from(duration.subsec_nanos()))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ use settings::install::InstallInfo;
 enum CommandResult {
     Authenticate(Result<Url, Error>),
     Concatenate(Result<(), Error>),
+    Play(Result<(), Error>),
     Record(Result<RecordLocation, Error>),
     Upload(Result<Url, Error>),
 }
@@ -58,6 +59,7 @@ fn main() {
         Action::Concatenate => {
             CommandResult::Concatenate(commands::concatenate::go(&settings.concatenate.unwrap()))
         }
+        Action::Play => CommandResult::Play(commands::play::go(&settings.play.unwrap())),
         Action::Record => CommandResult::Record(commands::record::go(
             &settings.record.unwrap(),
             UploadBuilder::default()
@@ -88,6 +90,10 @@ fn main() {
             Err(x) => handle_error(&x),
         },
         CommandResult::Concatenate(x) => match x {
+            Ok(()) => 0,
+            Err(x) => handle_error(&x),
+        },
+        CommandResult::Play(x) => match x {
             Ok(()) => 0,
             Err(x) => handle_error(&x),
         },

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -1,4 +1,5 @@
-use super::{AuthenticateSettings, ConcatenateSettings, RecordSettings, UploadSettings};
+use super::{AuthenticateSettings, ConcatenateSettings, PlaySettings, RecordSettings,
+            UploadSettings};
 use structopt::clap::AppSettings;
 
 #[derive(StructOpt, Debug)]
@@ -14,6 +15,10 @@ pub enum CommandLine {
     #[structopt(name = "cat")]
     #[structopt(raw(aliases = r#"&["c", "concatenate"]"#))]
     Concatenate(ConcatenateSettings),
+    /// Replay recorded asciicast in a terminal
+    #[structopt(name = "play")]
+    #[structopt(raw(aliases = r#"&["p", "play"]"#))]
+    Play(PlaySettings),
     /// Record terminal session
     #[structopt(name = "rec")]
     #[structopt(raw(aliases = r#"&["r", "record"]"#))]

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -15,6 +15,7 @@ use self::cli::CommandLine;
 pub enum Action {
     Authenticate,
     Concatenate,
+    Play,
     Record,
     Upload,
 }
@@ -24,6 +25,7 @@ pub struct Settings {
     pub api_url: Url,
     pub authenticate: Option<AuthenticateSettings>,
     pub concatenate: Option<ConcatenateSettings>,
+    pub play: Option<PlaySettings>,
     pub record: Option<RecordSettings>,
     pub upload: Option<UploadSettings>,
 }
@@ -47,6 +49,7 @@ impl Settings {
                 api_url,
                 authenticate: Some(AuthenticateSettings { ..x }),
                 concatenate: None,
+                play: None,
                 record: None,
                 upload: None,
             }),
@@ -55,6 +58,16 @@ impl Settings {
                 api_url,
                 authenticate: None,
                 concatenate: Some(ConcatenateSettings { ..x }),
+                play: None,
+                record: None,
+                upload: None,
+            }),
+            CommandLine::Play { 0: x } => Ok(Settings {
+                action: Action::Play,
+                api_url,
+                authenticate: None,
+                concatenate: None,
+                play: Some(PlaySettings { ..x }),
                 record: None,
                 upload: None,
             }),
@@ -63,6 +76,7 @@ impl Settings {
                 api_url,
                 authenticate: None,
                 concatenate: None,
+                play: None,
                 record: Some(RecordSettings { ..x }),
                 upload: None,
             }),
@@ -71,11 +85,25 @@ impl Settings {
                 api_url,
                 authenticate: None,
                 concatenate: None,
+                play: None,
                 record: None,
                 upload: Some(UploadSettings { ..x }),
             }),
         }
     }
+}
+
+#[derive(StructOpt, Clone, Debug, Deserialize)]
+pub struct PlaySettings {
+    /// Limit replayed terminal inactivity to max seconds
+    #[structopt(short = "i", long = "idle-time-limit")]
+    pub idle_time_limit: Option<f64>,
+    /// Playback speed
+    #[structopt(short = "s", long = "speed")]
+    pub speed: Option<f64>,
+    /// Location can be either local recording or remote recording
+    #[structopt(name = "LOCATION", parse(from_os_str))]
+    pub location: PathBuf,
 }
 
 #[derive(StructOpt, Clone, Debug, Deserialize)]


### PR DESCRIPTION
Resolves #1, #22, #23. 
This PR roughly implemented the `play` subcommand. The `play` command supports both local files and remote files. It is same as `cat` did. But I prefer to move these `pub` function to somewhere else and also move the Error Type to another place.